### PR TITLE
Replace deprecated FILTER_SANITIZE_STRING

### DIFF
--- a/src/SteamOpenID/SteamOpenID.php
+++ b/src/SteamOpenID/SteamOpenID.php
@@ -154,7 +154,7 @@ class SteamOpenID
             'openid_claimed_id' => FILTER_SANITIZE_URL,
             'openid_identity' => FILTER_SANITIZE_URL,
             'openid_return_to' => FILTER_SANITIZE_URL, // Should equal to url we sent
-            'openid_response_nonce' => FILTER_SANITIZE_STRING,
+            'openid_response_nonce' => ['filter' => FILTER_UNSAFE_RAW, 'flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH],
             'openid_assoc_handle' => FILTER_SANITIZE_SPECIAL_CHARS, // Steam just sends 1234567890
             'openid_signed' => FILTER_SANITIZE_SPECIAL_CHARS,
             'openid_sig' => FILTER_SANITIZE_SPECIAL_CHARS


### PR DESCRIPTION
PHP 8.1 deprecates FILTER_SANITIZE_STRING and recommends [htmlspecialchars()](https://www.php.net/manual/en/function.htmlspecialchars.php) instead, however in this case we are not filtering for XSS.

I've replaced the filter to instead strip characters outside the allowed ASCII range. This is documented in the specs here: https://openid.net/specs/openid-authentication-2_0.html#positive_assertions

An example nonce returned by steam:
```
2024-10-08T22:41:16ZT4LvYmNS5X//lKaQyJtqT4i0a44=
```