### PR TITLE
Add referer and origin header to OpenIDVerification request

### DIFF
--- a/src/SteamOpenID/SteamOpenID.php
+++ b/src/SteamOpenID/SteamOpenID.php
@@ -129,6 +129,7 @@ class SteamOpenID
             CURLOPT_TIMEOUT => 6,
             CURLOPT_POST => true,
             CURLOPT_POSTFIELDS => $arguments,
+            CURLOPT_HTTPHEADER => ['Referer: https://steamcommunity.com', 'Origin: https://steamcommunity.com']
         ]);
 
         $response = curl_exec($c);


### PR DESCRIPTION
Steam's servers updated and the verification will no longer work unless these are provided